### PR TITLE
Renaming _() methods

### DIFF
--- a/core/java/src/net/i2p/data/DataHelper.java
+++ b/core/java/src/net/i2p/data/DataHelper.java
@@ -1452,7 +1452,7 @@ public class DataHelper {
             // years
             t = ngettext("1 year", "{0} years", (int) (ms / (365L * 24 * 60 * 60 * 1000)));
         } else {
-            return _t("n/a");
+            return t("n/a");
         }
         // Replace minus sign to work around
         // bug in Chrome (and IE?), line breaks at the minus sign
@@ -1499,7 +1499,7 @@ public class DataHelper {
             // years
             t = ngettext("1 year", "{0} years", (int) (ms / (365L * 24 * 60 * 60 * 1000)));
         } else {
-            return _t("n/a");
+            return t("n/a");
         }
         if (ms < 0)
             t = t.replace("-", "&minus;");
@@ -1508,7 +1508,7 @@ public class DataHelper {
     
     private static final String BUNDLE_NAME = "net.i2p.router.web.messages";
 
-    private static String _t(String key) {
+    private static String t(String key) {
         return Translate.getString(key, I2PAppContext.getGlobalContext(), BUNDLE_NAME);
     }
 


### PR DESCRIPTION
Use of '_' identifire might not be supported in java 9. So I have updated the methods' name to stop the warning in java 8.