### PR TITLE
Add to apparmor profile java-11-openjdk support

### DIFF
--- a/debian/apparmor/i2p
+++ b/debian/apparmor/i2p
@@ -34,6 +34,8 @@
 
   /etc/java-*-openjdk/**                                  r,
   # Allow any JRE or JDK
+  /usr/lib/jvm/*/bin/java                                 rix,
+  /usr/lib/jvm/*/bin/keytool                              rix,
   /usr/lib/jvm/*/jre/bin/java                             rix,
   /usr/lib/jvm/*/jre/bin/keytool                          rix,
 


### PR DESCRIPTION
java-11-openjdk java binaries located at /usr/lib/jvm/java-11-openjdk-*/bin