### PR TITLE
daß -> dass (deprecated spelling since 1996)

### DIFF
--- a/apps/routerconsole/locale/messages_de.po
+++ b/apps/routerconsole/locale/messages_de.po
@@ -7896,7 +7896,7 @@ msgstr "Die Zahl der teilnehmenden Tunnel, die für andere geroutet werden, gete
 msgid ""
 "A number greater than 1.00 means you are contributing more tunnels to the "
 "network than you are using."
-msgstr "Eine Zahl größer als 1.00 bedeutet, daß man mehr Tunnel zum Netzwerk beiträgt als man nutzt."
+msgstr "Eine Zahl größer als 1.00 bedeutet, dass man mehr Tunnel zum Netzwerk beiträgt als man nutzt."
 
 #: ../jsp/WEB-INF/classes/net/i2p/router/web/jsp/viewprofile_jsp.java:238
 #: ../jsp/WEB-INF/classes/net/i2p/router/web/jsp/viewprofile_jsp.java:409

--- a/apps/routerconsole/resources/docs/readme_de.html
+++ b/apps/routerconsole/resources/docs/readme_de.html
@@ -142,7 +142,7 @@ If you need some help, there's <a href="https://geti2p.net/en/about/browser-conf
 <b>Check Your Logs</b><br><a href="/logs">Logs</a> may be helpful to resolve a problem.
 You may wish to paste excerpts in our <a href="http://i2pforum.i2p/" target="_blank">forum</a> for help, or perhaps <a href="http://paste.idk.i2p/" target="_blank">paste</a> it instead and reference the link on IRC for help.</li>
 
-<li>Überprüfen Sie, daß Java Up to Date ist. Stellen Sie sicher, daß Ihr Java up to date ist. Prüfen Sie Ihre Java-Version auf den letzen Zeilen Ihre Log-Einträge !</li>
+<li>Überprüfen Sie, dass Java Up to Date ist. Stellen Sie sicher, dass Ihr Java up to date ist. Prüfen Sie Ihre Java-Version auf den letzen Zeilen Ihre Log-Einträge !</li>
 <li>
 <b>Problems running on Legacy Hardware</b><br>
 [Linux/BSD] If you can't start the router with <code>i2p/i2prouter start</code> try the <code>runplain.sh</code> script in the same directory.


### PR DESCRIPTION
I tried joining the Transifex translation team, but joining isn't open for German.