### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
   - SONAR_SCANNER_OPTS="-Xmx2048m" 
 
 script:
-  - travis_wait 45 ./tests/scripts/travis.sh
+  - ./tests/scripts/travis.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
