### PR TITLE
debian: create a log dir on startup if absent

### DIFF
--- a/debian/i2p.init
+++ b/debian/i2p.init
@@ -96,6 +96,7 @@ do_start()
         || return 1
     [ -d $RUN ] || mkdir $RUN > /dev/null 2>&1
     [ -d $I2PTEMP ] || mkdir $I2PTEMP > /dev/null 2>&1
+    [ -d "/var/log/$NAME" ] || mkdir "/var/log/$NAME" > /dev/null 2>&1
     if [ -r $PIDFILE ]; then
         PID="$(cat ${PIDFILE})"
         if ! kill -0 $PID > /dev/null 2>&1; then

--- a/debian/i2p.service
+++ b/debian/i2p.service
@@ -39,6 +39,7 @@ User=i2psvc
 PermissionsStartOnly=true
 AppArmorProfile=system_i2p
 ExecStartPre=/bin/mkdir -p /tmp/i2p-daemon
+ExecStartPre=/bin/mkdir -p /var/log/i2p
 ExecStartPre=/bin/chown -R ${I2PUSER}:${I2PUSER} /var/log/i2p /run/i2p /tmp/i2p-daemon
 ExecStartPre=/bin/chmod 750 /var/log/i2p
 ExecStart=/usr/sbin/wrapper "$I2P_ARGS"


### PR DESCRIPTION
Recently I found a bug:

1. Install i2p
2. Run i2p service as usual
3. Drop directory `/var/log/i2p`
4. Restart i2p service:  `sudo systemctl restart i2p.service`

Result: i2p failed to start only because the log dir was removed by mistake or for another reason.

The purpose of this little PR is to create the log dir on start if necessary.