### PR TITLE
Update startapp.sh

### DIFF
--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -25,9 +25,9 @@ done
 if [ -f /.dockerenv ]; then
     echo "[startapp] Running in container"
     export IP_ADDR=$(hostname -i)
-    if echo "$IP_ADDR" | grep "172.17"; then
+    if echo "$IP_ADDR" | grep "172."; then
         echo "[startapp] Running in docker network"
-        sed -i "s/127.0.0.1/${IP_ADDR}/g" ./clients.config ./i2ptunnel.config
+        sed -i "s/127.0.0.1/0.0.0.0/g" ./clients.config ./i2ptunnel.config
     fi
 
 fi


### PR DESCRIPTION
When running via docker-compose.yml file and in it mapping for example ...
- "127.0.0.1:7656:7656"
- "127.0.0.1:7657:7657" ...
so those ports are only available on 127.0.0.1 on the host, this does not work with the standard delivered startapp.sh. All i2p ports inside the container must listen on 0.0.0.0 to be reachable from the host (on 127.0.0.1). Also my i2p-docker-network is on 172.21.x.x, so "grep 172.17." won't work.