### PR TITLE
Add missing CC0 copyright headers to EdDSA-Java classes

### DIFF
--- a/core/java/src/net/i2p/crypto/eddsa/EdDSABlinding.java
+++ b/core/java/src/net/i2p/crypto/eddsa/EdDSABlinding.java
@@ -1,3 +1,14 @@
+/**
+ * EdDSA-Java by str4d
+ *
+ * To the extent possible under law, the person who associated CC0 with
+ * EdDSA-Java has waived all copyright and related or neighboring rights
+ * to EdDSA-Java.
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
+ *
+ */
 package net.i2p.crypto.eddsa;
 
 import java.math.BigInteger;

--- a/core/java/src/net/i2p/crypto/eddsa/RedDSAEngine.java
+++ b/core/java/src/net/i2p/crypto/eddsa/RedDSAEngine.java
@@ -1,3 +1,14 @@
+/**
+ * EdDSA-Java by str4d
+ *
+ * To the extent possible under law, the person who associated CC0 with
+ * EdDSA-Java has waived all copyright and related or neighboring rights
+ * to EdDSA-Java.
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
+ *
+ */
 package net.i2p.crypto.eddsa;
 
 import java.security.MessageDigest;

--- a/core/java/src/net/i2p/crypto/eddsa/RedKeyPairGenerator.java
+++ b/core/java/src/net/i2p/crypto/eddsa/RedKeyPairGenerator.java
@@ -1,3 +1,14 @@
+/**
+ * EdDSA-Java by str4d
+ *
+ * To the extent possible under law, the person who associated CC0 with
+ * EdDSA-Java has waived all copyright and related or neighboring rights
+ * to EdDSA-Java.
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
+ *
+ */
 package net.i2p.crypto.eddsa;
 
 import java.security.KeyPair;


### PR DESCRIPTION
These missing copyright headers are a minor cause of concern for us. We're assuming that these files are CC0, as everything else in this package is, but explicit copyright headers would give us assurance.