### PR TITLE
Dockerfile: migrate to eclipse-temurin:17-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  eclipse-temurin:17-alpine as builder
+FROM eclipse-temurin:17-alpine as builder
 
 ENV APP_HOME="/i2p"
 ARG ANT_VERSION="1.10.15"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,19 @@
-FROM alpine:3.17.1 as builder
+FROM  eclipse-temurin:17-alpine as builder
 
 ENV APP_HOME="/i2p"
+ARG ANT_VERSION="1.10.15"
 
 WORKDIR /tmp/build
 COPY . .
 
-RUN apk add --virtual build-base gettext tar bzip2 apache-ant openjdk17 \
+RUN apk add --no-cache gettext tar bzip2 curl \
     && echo "build.built-by=Docker" >> override.properties \
-    && ant preppkg-linux-only \
-    && rm -rf pkg-temp/osid pkg-temp/lib/wrapper pkg-temp/lib/wrapper.* \
-    && apk del build-base gettext tar bzip2 apache-ant openjdk17
+    && curl https://dlcdn.apache.org//ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.bz2 | tar -jxf - -C /opt \
+    && /opt/apache-ant-${ANT_VERSION}/bin/ant preppkg-linux-only \
+    && rm -rf pkg-temp/osid pkg-temp/lib/wrapper pkg-temp/lib/wrapper.*
 
-FROM alpine:3.17.1
+FROM eclipse-temurin:17-alpine
 ENV APP_HOME="/i2p"
-
-RUN apk add openjdk17-jre ttf-dejavu
 
 WORKDIR ${APP_HOME}
 COPY --from=builder /tmp/build/pkg-temp .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-alpine as builder
+FROM docker.io/eclipse-temurin:17-alpine as builder
 
 ENV APP_HOME="/i2p"
 ARG ANT_VERSION="1.10.15"
@@ -12,7 +12,7 @@ RUN apk add --no-cache gettext tar bzip2 curl \
     && /opt/apache-ant-${ANT_VERSION}/bin/ant preppkg-linux-only \
     && rm -rf pkg-temp/osid pkg-temp/lib/wrapper pkg-temp/lib/wrapper.*
 
-FROM eclipse-temurin:17-alpine
+FROM docker.io/eclipse-temurin:17-jre-alpine
 ENV APP_HOME="/i2p"
 
 WORKDIR ${APP_HOME}


### PR DESCRIPTION
OpenJDK packages provided by distro maintainers are known to cause various issues and that is not the way to dockerize java app unless there is a specific reason to do so. Not to mention alpine:3.17.1is obsolete (EOL'ed on 2024-11-22) and not receiving security updates anymore. 
Here I suggest replacing base image with `eclipse-temurin:17-alpine`. This image is well suited the task and more importantly battletested.
And a couple more changes:
- Install ant from official binaries as well. Pin version.
- Since builder is discarded anyway there is no real point it uninstalling build-time dependencies. I still however added --no-cache flag to reduce disk io