### PR TITLE
Updated moved and removed broken hyperlinks in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ See [INSTALL.txt](INSTALL.txt) or the installation instructions for your system:
 - [Windows](https://i2p.net/en/docs/guides/installing-i2p-on-windows/)
 - [macOS](https://i2p.net/en/docs/guides/installing-i2p-on-macos/)
 - [Linux](https://i2p.net/en/docs/guides/installing-i2p-on-debian-and-ubuntu/)
+- [Android](https://play.google.com/store/apps/details?id=net.i2p.android)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 This is the source code for the reference Java implementation of I2P.
 
-Latest release: [https://i2p.net/download](https://i2p.net/download)
+Latest release: [https://i2p.net/en/downloads/](https://i2p.net/en/downloads/)
 
 ## Installing
 
-See [INSTALL.txt](INSTALL.txt) or [https://i2p.net/download](https://i2p.net/download) for installation instructions.
+See [INSTALL.txt](INSTALL.txt) or the installation instructions for your system:
+- [Windows](https://i2p.net/en/docs/guides/installing-i2p-on-windows/)
+- [macOS](https://i2p.net/en/docs/guides/installing-i2p-on-macos/)
+- [Linux](https://i2p.net/en/docs/guides/installing-i2p-on-debian-and-ubuntu/)
 
 ## Documentation
 
-[https://i2p.net/how](https://i2p.net/how)
+[https://i2p.net/en/docs/](https://i2p.net/en/docs/)
 
-FAQ: [https://i2p.net/faq](https://i2p.net/faq)
+FAQ: [https://i2p.net/en/docs/overview/faq/](https://i2p.net/en/docs/overview/faq/)
 
-API: [http://docs.i2p-projekt.de/javadoc/](http://docs.i2p-projekt.de/javadoc/)
-or run 'ant javadoc' then start at build/javadoc/index.html
+API: Run 'ant javadoc' then start at build/javadoc/index.html
 
 ## How to contribute / Hack on I2P
 


### PR DESCRIPTION
Notes:
- No general installation docs page available so linked each individual system;
- Existing Documentation > API link (.../javadoc/) is gone and /docs/api/ page redirects away so removed it entirely.
- `https://trac.i2p2.de/wiki/java` is kinda broken, the certificate's CN is incorrect and the page doesn't say anything about Java, but I didn't know what else to replace that link with so I just left it.
<img width="1439" height="814" alt="image" src="https://github.com/user-attachments/assets/878d000a-7f8e-4d7e-864a-7edcd2aa44b0" />
