### PR TITLE
Fix remote parsing robustness (NTCP2, garlic, datagram)

### DIFF
--- a/core/java/src/net/i2p/client/datagram/I2PDatagramDissector.java
+++ b/core/java/src/net/i2p/client/datagram/I2PDatagramDissector.java
@@ -88,7 +88,9 @@ public final class I2PDatagramDissector {
             
             // read payload
             rxPayloadLen = dgStream.read(rxPayload);
-            
+            if (rxPayloadLen < 0)
+                rxPayloadLen = 0;
+
             // calculate the hash of the payload
             if (type == SigType.DSA_SHA1) {
                 if (rxHash == null)

--- a/router/java/src/net/i2p/router/message/GarlicMessageParser.java
+++ b/router/java/src/net/i2p/router/message/GarlicMessageParser.java
@@ -184,6 +184,7 @@ public class GarlicMessageParser {
      *  @since public since 0.9.44
      */
     public CloveSet readCloveSet(byte data[], int offset) throws DataFormatException {
+        try {
         int numCloves = data[offset] & 0xff;
         offset++;
         //if (_log.shouldLog(Log.DEBUG))
@@ -211,5 +212,8 @@ public class GarlicMessageParser {
 
         CloveSet set = new CloveSet(cloves, cert, msgId, expiration);
         return set;
+        } catch (IndexOutOfBoundsException e) {
+            throw new DataFormatException("corrupt clove set", e);
+        }
     }
 }

--- a/router/java/src/net/i2p/router/transport/ntcp/InboundEstablishState.java
+++ b/router/java/src/net/i2p/router/transport/ntcp/InboundEstablishState.java
@@ -73,7 +73,7 @@ class InboundEstablishState extends EstablishBase implements NTCP2Payload.Payloa
     private int _version = 2;
 
     // same as I2PTunnelRunner
-    private static final int BUFFER_SIZE = 4*1024;
+    private static final int BUFFER_SIZE = MSG3P1_SIZE + 6000;
     private static final int MAX_DATA_READ_BUFS = 32;
     private static final ByteCache _dataReadBufs = ByteCache.getInstance(MAX_DATA_READ_BUFS, BUFFER_SIZE);
 

--- a/router/java/src/net/i2p/router/tunnel/InboundMessageDistributor.java
+++ b/router/java/src/net/i2p/router/tunnel/InboundMessageDistributor.java
@@ -35,6 +35,8 @@ class InboundMessageDistributor implements GarlicMessageReceiver.CloveReceiver {
     private final GarlicMessageReceiver _receiver;
     private final String _clientNickname;
     private final long _msgIDBloomXor;
+    private static final int MAX_CLOVE_DEPTH = 10;
+    private static final ThreadLocal<Integer> _cloveDepth = new ThreadLocal<Integer>();
     /**
      *  @param client null for router tunnel
      */
@@ -265,9 +267,24 @@ class InboundMessageDistributor implements GarlicMessageReceiver.CloveReceiver {
                 if (_log.shouldLog(Log.DEBUG))
                     _log.debug("local delivery instructions for clove: " + data.getClass().getSimpleName());
                 switch (type) {
-                  case GarlicMessage.MESSAGE_TYPE:
-                    _receiver.receive((GarlicMessage)data);
+                  case GarlicMessage.MESSAGE_TYPE: {
+                    Integer d = _cloveDepth.get();
+                    int depth = (d != null) ? d.intValue() : 0;
+                    if (depth < MAX_CLOVE_DEPTH) {
+                        _cloveDepth.set(Integer.valueOf(depth + 1));
+                        try {
+                            _receiver.receive((GarlicMessage)data);
+                        } finally {
+                            if (depth > 0)
+                                _cloveDepth.set(Integer.valueOf(depth));
+                            else
+                                _cloveDepth.remove();
+                        }
+                    } else if (_log.shouldWarn()) {
+                        _log.warn("Garlic cloves nested too deep");
+                    }
                     break;
+                  }
 
                   case DatabaseStoreMessage.MESSAGE_TYPE:
                         // Treat db store explicitly here (not in HandleFloodfillDatabaseStoreMessageJob),


### PR DESCRIPTION
Hardening for remotely-reachable parsing paths, found during a security audit.

None of these are known to crash the router (the transport read loops catch `RuntimeException`), but each is a real contained defect worth fixing. The datagram one mirrors a fix already made in i2pd.
